### PR TITLE
Add missing import to path.vale

### DIFF
--- a/stdlib/src/path/path.vale
+++ b/stdlib/src/path/path.vale
@@ -1,5 +1,6 @@
 import stdlib.collections.list.*;
 import stdlib.resultutils.*;
+import stdlib.stringutils.*;
 
 export Array<imm, str> as StrArray;
 export Array<mut, str> as MutStrArray;


### PR DESCRIPTION
Used here:

https://github.com/jinyus/Vale/blob/02f39df7d8add54b5c01d453c34483a01b26cc44/stdlib/src/path/path.vale#L137

Error without it:
```
Error: stdlib.path:/home/dev/programs/vale_0.2.0.28/stdlib/src/path/path.vale:134:31 error T
  new_segments = segment.split(GetPathSeparator());
Couldn't find a suitable function split(str, str). No function with that name exists.
```